### PR TITLE
feat: support command as string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "jake"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jake"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 license-file = "LICENSE"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Here is an example for task definition:
 
 ```toml
 default = { command = "cat README.md" }
-say-hello = { command = "echo 'hello'" }
+say-hello = "echo 'hello'"
 say-hello-back = { command = "echo 'hello back'" }
 say-bye = { command = "echo 'bye'", depends_on = ["say-hello", "say-hello-back"] }
-list = { command = "ls" }
+list = "ls"
 ```
 
 And here is the anatomy of a definition:
@@ -39,7 +39,9 @@ Task name    Command to execute    Array of tasks to be executed _before_
                                                the task itself
 ```
 
-While `depends_on` is optional (if not provided, the task does not depend on anything), `command` is a required key.
+While `depends_on` is optional (if not provided, the task does not depend on anything), `command` is a required key if the provided TOML value is an object (as for `say-hello-back`, `default` and `say-bye`).
+
+In cases where the command does not depend on anything, you can also provide it as a plain string (as for `say-hello` and `list`).
 
 You can use the `default` task name to indicate the task that should be executed by default when none is provided to `jake` (otherwise, the default task will be the first one in the file).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cle-does-things/jake",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "A Rust-native implementation of the RAG stack",
   "main": "start.js",
   "directories": {

--- a/pre-install.js
+++ b/pre-install.js
@@ -31,8 +31,8 @@ const features = process.env.npm_config_features
   ? `--features ${process.env.npm_config_features.replace(",", " ")}`
   : "";
 
-console.log(`Installing and compiling jake 0.1.1 ${features} ...`);
-exec(`cargo install jake --vers 0.1.1 ${features}`, (error, stdout, stderr) => {
+console.log(`Installing and compiling jake 0.2.0 ${features} ...`);
+exec(`cargo install jake --vers 0.2.0 ${features}`, (error, stdout, stderr) => {
   console.log(stdout);
   if (error || stderr) {
     console.log(error || stderr);

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ mod models;
 
 /// Make-like task executor for Unix-based operating systems
 #[derive(Parser, Debug)]
-#[command(version = "0.1.1")]
+#[command(version = "0.2.0")]
 #[command(name = "jake")]
 #[command(about, long_about = None)]
 struct Args {

--- a/testfiles/jakefile.toml
+++ b/testfiles/jakefile.toml
@@ -2,3 +2,5 @@ say-hello = { command = "echo 'hello'" }
 say-hello-back = { command = "echo 'hello back'" }
 say-bye = { command = "echo 'bye'", depends_on = ["say-hello", "say-hello-back"] }
 list = { command = "ls" }
+strcmd = "echo ciao"
+wrongcommand = { command = ["echo hola"] }

--- a/testfiles/withdefault.toml
+++ b/testfiles/withdefault.toml
@@ -1,2 +1,4 @@
 false = { command = "false" }
 default = { command = "true" }
+error = ["something", "something-else"]
+nocommand = { depends_on = ["hello"] }


### PR DESCRIPTION
Support task definition as string. Now, both:

```toml
say-hello = "echo 'hello'"
```

and:

```toml
say-hello = { command = "echo 'hello'" }
```

are supported.

It is still required to pass an object when a task depends on other tasks.
