### PR TITLE
feat: add --dry-run to print commands without executing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jake"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jake"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license-file = "LICENSE"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ It is based on TOML tasks definition (stored in a file called `jakefile.toml`) a
 - You can list tasks, by passing the `--list` flag
 - You can load `.env` file (in the same working directory or anywhere up in the directory tree), by passing the `--env` flag
 - Execute scripts from a `package.json` file with the `--js` flag.
+- Dry-run mode: `jake --dry-run <task>` prints commands without executing them.
 
 ## Installation
 
@@ -185,6 +186,19 @@ jake dev --js
 ```
 
 You can invoke a script from the directory in which `package.json` is stored and from all its subdirectories.
+
+**Dry-run**
+
+To see which commands would run without executing them:
+
+```bash
+jake say-bye --dry-run
+```
+```text
+echo 'hello'
+echo 'hello back'
+echo 'bye'
+```
 
 ## In GitHub CI/CD
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cle-does-things/jake",
-  "version": "0.6.0",
-  "description": "A Rust-native implementation of the RAG stack",
+  "version": "0.7.0",
+  "description": "A Make-like task executor for Unix operating systems",
   "main": "start.js",
   "directories": {
     "test": "tests"

--- a/pre-install.js
+++ b/pre-install.js
@@ -31,8 +31,8 @@ const features = process.env.npm_config_features
   ? `--features ${process.env.npm_config_features.replace(",", " ")}`
   : "";
 
-console.log(`Installing and compiling jake 0.6.0 ${features} ...`);
-exec(`cargo install jake --vers 0.6.0 ${features}`, (error, stdout, stderr) => {
+console.log(`Installing and compiling jake 0.7.0 ${features} ...`);
+exec(`cargo install jake --vers 0.7.0 ${features}`, (error, stdout, stderr) => {
   console.log(stdout);
   if (error || stderr) {
     console.log(error || stderr);

--- a/reference/contents/features.md
+++ b/reference/contents/features.md
@@ -3,41 +3,49 @@ intro: Features
 tagline: Jake features and comparison
 ---
 
-`jake` (crasis for "just make") is a [Make](https://en.wikipedia.org/wiki/Make_(software))-like task executor for Unix-based operating systems.
-It is based on TOML task definitions (stored in a file called `jakefile.toml`) and can execute commands by resolving their dependencies and forwarding additional options from the command line.
+`jake` (crasis for "just make") is a [Make](https://en.wikipedia.org/wiki/Make_(software))-like
+task executor for Unix-based operating systems. It is based on TOML task definitions (stored in a
+file called `jakefile.toml`) and can execute commands by resolving their dependencies and forwarding
+additional options from the command line.
 
 ### Features
 
-- **Boilerplate initialization**: with the `--init` option, you can create a boilerplate `jakefile.toml`
+- **Boilerplate initialization**: with the `--init` option, you can create a boilerplate
+  `jakefile.toml`
 - **Simple TOML syntax** for task definition: no `.PHONY` declarations, no spacing rules
 - **Dependency resolution** with circular dependency detection
 - **Extra arguments** can be passed as options directly from the command line
 - **Default task execution** when no task name is specified
 - **Composite commands** support (e.g. `cat README.md | grep Features` or `cd src/ && pwd`)
-- **Subdirectory awareness**: tasks can be invoked from any subdirectory of the directory containing `jakefile.toml`
+- **Subdirectory awareness**: tasks can be invoked from any subdirectory of the directory containing
+  `jakefile.toml`
 - **Listing tasks**: tasks can be listed with the `--list` flag
 - **Loading .env files**: `.env` files can be loaded for task execution with the `--env` flag
-- **Executing package.json scripts**: in a JS/TS environment, scripts contained in a `package.json` file can be executed by passing the `--js` flag
+- **Executing package.json scripts**: in a JS/TS environment, scripts contained in a `package.json`
+  file can be executed by passing the `--js` flag
+- **Dry-run**: `--dry-run` prints the commands that would be run without executing them
 
 ### Comparison
 
-The table below compares `jake` against [`just`](https://github.com/casey/just) and [`make`](https://en.wikipedia.org/wiki/Make_(software)) across key features:
+The table below compares `jake` against [`just`](https://github.com/casey/just) and
+[`make`](https://en.wikipedia.org/wiki/Make_(software)) across key features:
 
-| Feature                          | jake | just | make |
-|----------------------------------|------|------|------|
-| Dependency graph resolution      | ✅   | ✅    | ✅  |
-| Circular dependency detection    | ✅   | ✅    | ❌   |
-| Extra arguments / options        | ✅   | ✅   | ⚠️  |
-| Default task execution           | ✅   | ✅   | ✅  |
-| Composite commands               | ✅   | ✅   | ✅  |
-| Subdirectory invocation          | ✅   | ✅   | ❌   |
-| Simple, readable syntax          | ✅   | ✅   | ❌   |
-| No special spacing rules         | ✅   | ✅   | ❌   |
-| Read .env                        | ✅    | ✅   | ❌   |
-| List available commands          | ✅    | ✅   | ❌   |
-| Recipes written in arbitrary languages | ❌ | ✅   | ❌   |
-| Initialize a boilerplate jake/just/makefile | ✅ | ❌   | ❌   |
-| Execute scripts in `package.json` | ✅ | ❌  | ❌  |
+| Feature                                     | jake | just | make |
+| ------------------------------------------- | ---- | ---- | ---- |
+| Dependency graph resolution                 | ✅   | ✅   | ✅   |
+| Circular dependency detection               | ✅   | ✅   | ❌   |
+| Extra arguments / options                   | ✅   | ✅   | ⚠️   |
+| Default task execution                      | ✅   | ✅   | ✅   |
+| Composite commands                          | ✅   | ✅   | ✅   |
+| Subdirectory invocation                     | ✅   | ✅   | ❌   |
+| Simple, readable syntax                     | ✅   | ✅   | ❌   |
+| No special spacing rules                    | ✅   | ✅   | ❌   |
+| Read .env                                   | ✅   | ✅   | ❌   |
+| List available commands                     | ✅   | ✅   | ❌   |
+| Recipes written in arbitrary languages      | ❌   | ✅   | ❌   |
+| Initialize a boilerplate jake/just/makefile | ✅   | ❌   | ❌   |
+| Execute scripts in `package.json`           | ✅   | ❌   | ❌   |
+| Dry-run (print commands only)               | ✅   | ✅   | ✅   |
 
-
-⚠️ `make` supports passing variables from the command line but not named options in the same ergonomic way.
+⚠️ `make` supports passing variables from the command line but not named options in the same
+ergonomic way.

--- a/reference/contents/reference.md
+++ b/reference/contents/reference.md
@@ -135,6 +135,19 @@ jake say-bye
 'bye'
 ```
 
+**Dry-run (print commands without running them)**
+
+Use `--dry-run` to print each command that would be run, in order, without executing anything. Useful for debugging or auditing task graphs.
+
+```bash
+jake say-bye --dry-run
+```
+```text
+echo 'hello'
+echo 'hello back'
+echo 'bye'
+```
+
 **Pass additional options to a task**
 
 You can forward extra flags to the underlying command using `--options`:

--- a/src/load.rs
+++ b/src/load.rs
@@ -79,13 +79,13 @@ fn task_to_task_node(available_tasks: &Map<String, Value>, task: &str) -> Result
             ));
         }
         let mut dependencies: Vec<String> = vec![];
-        if task_table.contains_key("depends_on")
-            && let Some(depends) = task_table["depends_on"].as_array()
-        {
-            for value in depends {
-                match value.as_str() {
-                    Some(c) => dependencies.push(c.to_string()),
-                    None => continue,
+        if task_table.contains_key("depends_on") {
+            if let Some(depends) = task_table["depends_on"].as_array() {
+                for value in depends {
+                    match value.as_str() {
+                        Some(c) => dependencies.push(c.to_string()),
+                        None => continue,
+                    }
                 }
             }
         }

--- a/src/load.rs
+++ b/src/load.rs
@@ -219,7 +219,7 @@ pub fn execute_default_command(
 mod tests {
     use serial_test::serial;
 
-    use crate::models::CommandExecutor;
+    use crate::models::{CommandExecutor, DryRunExecutor};
 
     use super::*;
 
@@ -620,5 +620,23 @@ mod tests {
         for task in &expected_tasks {
             assert!(tasks.contains(task))
         }
+    }
+
+    #[test]
+    #[serial]
+    fn test_dry_run_executor_command() {
+        let path = Some("testfiles/jakefile.toml");
+        let executor = DryRunExecutor::new();
+        let result = execute_command(path, "say-hello", "", &executor, false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn test_dry_run_executor_default_command() {
+        let path = Some("testfiles/withdefault.toml");
+        let executor = DryRunExecutor::new();
+        let result = execute_default_command(path, "", &executor, false);
+        assert!(result.is_ok());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use crate::{
     initialize::write_jakefile,
     load::{execute_command, execute_default_command, is_posix_os, list_jakefile_tasks},
-    models::CommandExecutor,
+    models::{CommandExecutor, DryRunExecutor},
     package_json::execute_script,
 };
 use anyhow::anyhow;
@@ -41,6 +41,10 @@ struct Args {
     /// Initialize a Jakefile by providing a list of comma-separated tasks
     #[arg(long, default_value = None)]
     init: Option<String>,
+
+    /// Print commands that would be run without executing them
+    #[arg(long, default_value_t = false)]
+    dry_run: bool,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -60,10 +64,14 @@ fn main() -> anyhow::Result<()> {
         println!("Available tasks:\n- {}\n", task_list);
         return Ok(());
     }
-    let executor = CommandExecutor::new();
+    let executor: Box<dyn models::Executor> = if args.dry_run {
+        Box::new(DryRunExecutor)
+    } else {
+        Box::new(CommandExecutor::new())
+    };
     if args.js {
         if let Some(script_name) = args.task {
-            execute_script(None, script_name, args.env, &executor)?;
+            execute_script(None, script_name, args.env, executor.as_ref())?;
         } else {
             return Err(anyhow!(
                 "No script name provided, please provide one or, if you wish to execute the default command from jakefile.toml, do not pass the `--js` flag."
@@ -72,8 +80,8 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
     match args.task {
-        Some(t) => execute_command(None, &t, &args.options, &executor, args.env)?,
-        None => execute_default_command(None, &args.options, &executor, args.env)?,
+        Some(t) => execute_command(None, &t, &args.options, executor.as_ref(), args.env)?,
+        None => execute_default_command(None, &args.options, executor.as_ref(), args.env)?,
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ mod package_json;
 
 /// Make-like task executor for Unix-based operating systems
 #[derive(Parser, Debug)]
-#[command(version = "0.6.0")]
+#[command(version = "0.7.0")]
 #[command(name = "jake")]
 #[command(about, long_about = None)]
 struct Args {
@@ -65,7 +65,7 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
     let executor: Box<dyn models::Executor> = if args.dry_run {
-        Box::new(DryRunExecutor)
+        Box::new(DryRunExecutor::new())
     } else {
         Box::new(CommandExecutor::new())
     };

--- a/src/models.rs
+++ b/src/models.rs
@@ -14,6 +14,20 @@ impl CommandExecutor {
     }
 }
 
+/// Executor that prints the command and does not run it (for --dry-run).
+pub struct DryRunExecutor;
+
+impl Executor for DryRunExecutor {
+    fn execute(&self, main_command: &str, args: Vec<&str>, _load_env: bool) -> anyhow::Result<()> {
+        let full_command = std::iter::once(main_command)
+            .chain(args.into_iter())
+            .collect::<Vec<_>>()
+            .join(" ");
+        println!("{}", full_command);
+        Ok(())
+    }
+}
+
 impl Executor for CommandExecutor {
     fn execute(&self, main_command: &str, args: Vec<&str>, load_env: bool) -> anyhow::Result<()> {
         let mut command_args = args;

--- a/src/models.rs
+++ b/src/models.rs
@@ -17,11 +17,17 @@ impl CommandExecutor {
 /// Executor that prints the command and does not run it (for --dry-run).
 pub struct DryRunExecutor;
 
+impl DryRunExecutor {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
 impl Executor for DryRunExecutor {
     fn execute(&self, main_command: &str, args: Vec<&str>, _load_env: bool) -> anyhow::Result<()> {
         let full_command = std::iter::once(main_command)
             .chain(args.into_iter())
-            .collect::<Vec<_>>()
+            .collect::<Vec<&str>>()
             .join(" ");
         println!("{}", full_command);
         Ok(())

--- a/src/package_json.rs
+++ b/src/package_json.rs
@@ -84,7 +84,7 @@ pub fn execute_script(
 
 #[cfg(test)]
 mod tests {
-    use crate::models::CommandExecutor;
+    use crate::models::{CommandExecutor, DryRunExecutor};
 
     use super::*;
 
@@ -253,6 +253,15 @@ mod tests {
     #[serial]
     fn test_command_execution() {
         let executor = CommandExecutor::new();
+        let path = Some("testfiles/test-package.json".to_string());
+        let result = execute_script(path, "test".to_string(), false, &executor);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn test_dry_run_command_execution() {
+        let executor = DryRunExecutor::new();
         let path = Some("testfiles/test-package.json".to_string());
         let result = execute_script(path, "test".to_string(), false, &executor);
         assert!(result.is_ok());


### PR DESCRIPTION
- Add `DryRunExecutor` and `--dry-run` flag so users can see the command sequence that would run, without executing anything.
- In `load.rs`, replace the unstable `"if cond && let Some(x) = ..."` (let-chains) with nested `"if cond { if let Some(x) = ... }"` so the project builds on stable Rust.